### PR TITLE
Add limit/count to getTagMedia

### DIFF
--- a/instagram.class.php
+++ b/instagram.class.php
@@ -263,8 +263,8 @@ class Instagram {
    * @param string $name                  Valid tag name
    * @return mixed
    */
-  public function getTagMedia($name) {
-    return $this->_makeCall('tags/' . $name . '/media/recent');
+  public function getTagMedia($name, $limit) {
+    return $this->_makeCall('tags/' . $name . '/media/recent', false, array('count' => $limit));
   }
 
   /**
@@ -445,7 +445,7 @@ class Instagram {
   public function getApiSecret() {
     return $this->_apisecret;
   }
-	
+  
   /**
    * API Callback URL Setter
    * 


### PR DESCRIPTION
I've noticed that only a few photos where loading as recent activity was low
Now you can do getTagMedia($tag, 32) so more 32 photos are loaded by default
