### PR TITLE
support pagination for user likes and tags

### DIFF
--- a/instagram.class.php
+++ b/instagram.class.php
@@ -380,7 +380,11 @@ class Instagram {
       }
       $function = str_replace(self::API_URL, '', $apiCall[0]);
       $auth = (strpos($apiCall[1], 'access_token') !== false);
-      if (isset($obj->pagination->next_max_id)) {
+      if (isset($obj->pagination->next_max_like_id)) {
+        return $this->_makeCall($function, $auth, array('max_like_id' => $obj->pagination->next_max_like_id, 'count' => $limit));
+      }elseif (isset($obj->pagination->next_max_tag_id)) {
+        return $this->_makeCall($function, $auth, array('max_tag_id' => $obj->pagination->next_max_tag_id, 'count' => $limit));
+      }elseif(isset($obj->pagination->next_max_id)) {
         return $this->_makeCall($function, $auth, array('max_id' => $obj->pagination->next_max_id, 'count' => $limit));
       } else {
         return $this->_makeCall($function, $auth, array('cursor' => $obj->pagination->next_cursor, 'count' => $limit));


### PR DESCRIPTION
next_max_id is deprecated for tags we should use next_max_tag_id instead
max_like_id is used with user likes and not max_id
