### PR TITLE
[BUGFIX] Avoid PHP short tags

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -39,7 +39,7 @@ $loginUrl = $instagram->getLoginUrl();
         <ul class="grid">
           <li><img src="assets/instagram-big.png" alt="Instagram logo"></li>
           <li>
-            <a class="login" href="<? echo $loginUrl ?>">» Login with Instagram</a>
+            <a class="login" href="<?php echo $loginUrl ?>">» Login with Instagram</a>
             <h>Use your Instagram account to login.</h4>
           </li>
         </ul>

--- a/example/success.php
+++ b/example/success.php
@@ -58,7 +58,7 @@ if (isset($code)) {
     <div class="container">
       <header class="clearfix">
         <img src="assets/instagram.png" alt="Instagram logo">
-        <h1>Instagram photos <span>taken by <? echo $data->user->username ?></span></h1>
+        <h1>Instagram photos <span>taken by <?php echo $data->user->username ?></span></h1>
       </header>
       <div class="main">
         <ul class="grid">


### PR DESCRIPTION
Avoid short open tags (since they requires a
specific configuration, confict with XML processing
instructions and are officially discouraged)
