### PR TITLE
[BUGFIX] Avoid PHP warning due to empty captions

### DIFF
--- a/example/popular.php
+++ b/example/popular.php
@@ -47,7 +47,7 @@ $result = $instagram->getPopularMedia();
             // create meta section
             $avatar = $media->user->profile_picture;
             $username = $media->user->username;
-            $comment = $media->caption->text;
+            $comment = (!empty($media->caption->text))? $media->caption->text : '';
             $content .= "<div class=\"content\">
                            <div class=\"avatar\" style=\"background-image: url({$avatar})\"></div>
                            <p>{$username}</p>

--- a/example/success.php
+++ b/example/success.php
@@ -85,7 +85,7 @@ if (isset($code)) {
             // create meta section
             $avatar = $media->user->profile_picture;
             $username = $media->user->username;
-            $comment = $media->caption->text;
+            $comment = (!empty($media->caption->text))? $media->caption->text : '';
             $content .= "<div class=\"content\">
                            <div class=\"avatar\" style=\"background-image: url({$avatar})\"></div>
                            <p>{$username}</p>


### PR DESCRIPTION
A php warning is thrown if the caption for a media
item is empty. Avoid such warning in the examples.

Refs #33
