### PR TITLE
Fixed pagination for getUserLikes() method

### DIFF
--- a/instagram.class.php
+++ b/instagram.class.php
@@ -382,6 +382,8 @@ class Instagram {
       $auth = (strpos($apiCall[1], 'access_token') !== false);
       if (isset($obj->pagination->next_max_id)) {
         return $this->_makeCall($function, $auth, array('max_id' => $obj->pagination->next_max_id, 'count' => $limit));
+      } elseif (isset($obj->pagination->next_max_like_id)) {
+        return $this->_makeCall($function, $auth, array('max_like_id' => $obj->pagination->next_max_like_id, 'count' => $limit));
       } else {
         return $this->_makeCall($function, $auth, array('cursor' => $obj->pagination->next_cursor, 'count' => $limit));
       }


### PR DESCRIPTION
For some odd reason the Instagram API returns `max_liked_id` and `next_max_like_id` instead of `max_id` and `next_max_id` that seems to be used for the other pagination situations. My updates here simply look these `_like_` attributes in the event the normal ones are not set.

Previously using a `do-while` loop to paginate through `getUserLikes()` was producing an endless loop for me and never actually parsing the next page of results. It now paginates correctly and I have no issue.