### PR TITLE
Alternative fix for composer autoload issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,6 @@
 		"ext-curl": "*"
 	},
 	"autoload": {
-		"psr-0": {
-			"Instagram": "lib/"
-		}
+        "classmap": ["./"]
 	}
 }


### PR DESCRIPTION
Fixes #37 without moving files around or introducing namespaces. A simpler alternative to pull requests #46 and #47.
