### PR TITLE
Add support for media shortcode.

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -237,6 +237,16 @@ class Instagram {
   public function getMedia($id) {
     return $this->_makeCall('media/' . $id);
   }
+  
+    /**
+   * Get media by its shortcode
+   *
+   * @param string $shortcode                   Instagram media shortcode
+   * @return mixed
+   */
+  public function getMediaShortcode($shortcode) {
+    return $this->_makeCall('media/shortcode/' . $shortcode);
+  }
 
   /**
    * Get the most popular media


### PR DESCRIPTION
This endpoint returns the same response as GET /media/media-id.
A media object's shortcode can be found in its shortlink URL.
An example shortlink is http://instagram.com/p/D/
Its corresponding shortcode is D.
