### PR TITLE
Create two new location methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A PHP wrapper for the Instagram API.
 Feedback or bug reports are appreciated.
 
-> [Composer](#installation) package available.  
+> [Composer](#installation) package available.
 > Supports [Instagram Video](#instagram-videos) and [Signed Header](#signed-header).
 
 ## Requirements
@@ -36,13 +36,13 @@ I strongly advice using [Composer](https://getcomposer.org) to keep updates as s
 <?php
     require_once 'Instagram.php';
     use MetzWeb\Instagram\Instagram;
-    
+
     $instagram = new Instagram(array(
       'apiKey'      => 'YOUR_APP_KEY',
       'apiSecret'   => 'YOUR_APP_SECRET',
       'apiCallback' => 'YOUR_APP_CALLBACK'
     ));
-    
+
     echo "<a href='{$instagram->getLoginUrl()}'>Login with Instagram</a>";
 ?>
 ```
@@ -54,7 +54,7 @@ I strongly advice using [Composer](https://getcomposer.org) to keep updates as s
     // grab OAuth callback code
     $code = $_GET['code'];
     $data = $instagram->getOAuthToken($code);
-    
+
     echo 'Your username is: ' . $data->user->username;
 ?>
 ```
@@ -65,10 +65,10 @@ I strongly advice using [Composer](https://getcomposer.org) to keep updates as s
 <?php
     // set user access token
     $instagram->setAccessToken($data);
-    
+
     // get all user likes
     $likes = $instagram->getUserLikes();
-    
+
     // take a look at the API response
     echo '<pre>';
     print_r($likes);
@@ -145,7 +145,7 @@ getLoginUrl(array(
 
 `getOAuthToken($code, <true>/<false>)`
 
-`true` : Returns only the OAuth token  
+`true` : Returns only the OAuth token
 `false` *[default]* : Returns OAuth token and profile data of the authenticated user
 
 ### Set / Get access token
@@ -252,6 +252,24 @@ Please note that the authenticated methods require the `comments` [scope](#get-l
 
 > How to like a Media: [Example usage](https://gist.github.com/3287237)
 > [Sample responses of the Likes Endpoints.](http://instagram.com/developer/endpoints/likes/)
+
+### Location methods
+
+**Public methods**
+
+- `getLocation($id)`
+    - `$id` : Instagram's location id.
+- `getLocationMedia($id)`
+    - `$id` : Instagram's location id.
+- `searchLocation($lat, $lng, <$distance>)`
+    - `$lat` and `$lng` are coordinates and have to be floats like: `48.145441892290336`,`11.568603515625`
+    - `$distance` : Radial distance in meter (default is 1km = 1000, max. is 5km = 5000)
+- `searchLocationByFacebookPlaceId($id)`
+    - `$id` : Facebook Places ID.
+- `searchLocationByFoursquareId($id)`
+    - `$id` : Foursquare V2 ID.
+
+> [Sample responses of the Location Endpoints.](http://instagram.com/developer/endpoints/locations/)
 
 All `<...>` parameters are optional. If the limit is undefined, all available results will be returned.
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -378,15 +378,15 @@ class Instagram {
    * Returns a location mapped off of a Facebook places id. If used, a
    * Foursquare id and lat, lng are not required.
    *
-   * @param int $facebook_place_id  Facebook place id
+   * @param int $id                       Facebook place id
    *
    * @return mixed
    */
-  public function searchLocationByFacebookPlaceId($facebook_place_id) {
+  public function searchLocationByFacebookPlaceId($id) {
     return $this->_makeCall(
       'locations/search',
       false,
-      ['FACEBOOK_PLACES_ID' => $facebook_place_id]
+      ['FACEBOOK_PLACES_ID' => $id]
     );
   }
 
@@ -396,15 +396,15 @@ class Instagram {
    * Returns a location mapped off of a foursquare v2 api location id. If used,
    * you are not required to use lat and lng.
    *
-   * @param int $foursquare_v2_id  Foursquare V2 ID
+   * @param int $id                       Foursquare V2 ID
    *
    * @return mixed
    */
-  public function searchLocationByFoursquareId($foursquare_v2_id) {
+  public function searchLocationByFoursquareId($id) {
     return $this->_makeCall(
       'locations/search',
       false,
-      ['FOURSQUARE_V2_ID' => $foursquare_v2_id]
+      ['FOURSQUARE_V2_ID' => $id]
     );
   }
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -386,7 +386,7 @@ class Instagram {
     return $this->_makeCall(
       'locations/search',
       false,
-      ['FACEBOOK_PLACES_ID' => $id]
+      ['facebook_places_id' => $id]
     );
   }
 
@@ -404,7 +404,7 @@ class Instagram {
     return $this->_makeCall(
       'locations/search',
       false,
-      ['FOURSQUARE_V2_ID' => $id]
+      ['foursquare_v2_id' => $id]
     );
   }
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -361,7 +361,7 @@ class Instagram {
   }
 
   /**
-   * Get recent media from a given location
+   * Search for a location by geographic coordinate.
    *
    * @param float $lat                    Latitude of the center search coordinate
    * @param float $lng                    Longitude of the center search coordinate
@@ -370,6 +370,42 @@ class Instagram {
    */
   public function searchLocation($lat, $lng, $distance = 1000) {
     return $this->_makeCall('locations/search', false, array('lat' => $lat, 'lng' => $lng, 'distance' => $distance));
+  }
+
+  /**
+   * Search for a location by Facebook Places ID.
+   *
+   * Returns a location mapped off of a Facebook places id. If used, a
+   * Foursquare id and lat, lng are not required.
+   *
+   * @param int $facebook_place_id  Facebook place id
+   *
+   * @return mixed
+   */
+  public function searchLocationByFacebookPlaceId($facebook_place_id) {
+    return $this->_makeCall(
+      'locations/search',
+      false,
+      ['FACEBOOK_PLACES_ID' => $facebook_place_id]
+    );
+  }
+
+  /**
+   * Search for a location by Foursquare V2 ID.
+   *
+   * Returns a location mapped off of a foursquare v2 api location id. If used,
+   * you are not required to use lat and lng.
+   *
+   * @param int $foursquare_v2_id  Foursquare V2 ID
+   *
+   * @return mixed
+   */
+  public function searchLocationByFoursquareId($foursquare_v2_id) {
+    return $this->_makeCall(
+      'locations/search',
+      false,
+      ['FOURSQUARE_V2_ID' => $foursquare_v2_id]
+    );
   }
 
   /**
@@ -558,7 +594,7 @@ class Instagram {
   /**
    * API Secret Setter
    *
-   * @param string $apiSecret 
+   * @param string $apiSecret
    * @return void
    */
   public function setApiSecret($apiSecret) {
@@ -573,7 +609,7 @@ class Instagram {
   public function getApiSecret() {
     return $this->_apisecret;
   }
-  
+
   /**
    * API Callback URL Setter
    *


### PR DESCRIPTION
This pull request creates two new locations methods to be used on "location/search" endpoint.

One is for search for an Instagram's location by a Facebook Places ID, the other is for search for an Instagram's location by a Foursquare V2 ID.

Docs for location's methods were added.
