### PR TITLE
Add curl timeout

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -460,6 +460,7 @@ class Instagram {
     curl_setopt($ch, CURLOPT_URL, $apiCall);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headerData);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 20);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 90);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 


### PR DESCRIPTION
Omitting `CURLOPT_TIMEOUT` can cause connections to hang indefinitely, for example due to network connectivity problems that occur after connecting, but before completing the request. This can lead to processes that run forever.

Setting a curl timeout prevents this.