### PR TITLE
Add CURL timeouts

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -460,6 +460,7 @@ class Instagram {
     curl_setopt($ch, CURLOPT_URL, $apiCall);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headerData);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 20);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 300);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
@@ -495,6 +496,7 @@ class Instagram {
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 300);
 
     $jsonData = curl_exec($ch);
     if (false === $jsonData) {


### PR DESCRIPTION
Some calls may otherwise continue forever (this may be crucial for long-running applications).