### PR TITLE
Add .gitattributes file for smaller download size.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/example export-ignore


### PR DESCRIPTION
When adding this library to a project everyone might not want the example folder to be included. With this `.gitattributes` file it can be ignored.