### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock


### PR DESCRIPTION
This is quite common since we don't want anyone to accidentally push vendor directory or the composer.lock file.