### PR TITLE
Check X-Ratelimit-Remaining header for existing

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -542,7 +542,7 @@ class Instagram {
     $headers = $this->processHeaders($headerContent);
 
     // get the 'X-Ratelimit-Remaining' header value
-    $this->_xRateLimitRemaining = $headers['X-Ratelimit-Remaining'];
+    $this->_xRateLimitRemaining = isset($headers['X-Ratelimit-Remaining']) ? $headers['X-Ratelimit-Remaining'] : 0;
 
     if (!$jsonData) {
       throw new InstagramException("Error: _makeCall() - cURL error: " . curl_error($ch));


### PR DESCRIPTION
In case we already spent the limit X-Ratelimit-Remaining header doesn't exist. So I think we can safely set it to the zero.