### PR TITLE
Set getTagMedia method as an authentication method.

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -314,7 +314,7 @@ class Instagram {
    * @return mixed
    */
   public function getTagMedia($name, $limit = 0) {
-    return $this->_makeCall('tags/' . $name . '/media/recent', false, array('count' => $limit));
+    return $this->_makeCall('tags/' . $name . '/media/recent', true, array('count' => $limit));
   }
 
   /**


### PR DESCRIPTION
Due recently changes on instagram api, getTagMedia() is not longer available without authentication. This request set the method true to treat as it's supposed to be. 