### PR TITLE
Revert "Update Instagram.php"

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -548,7 +548,6 @@ class Instagram {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $apiCall);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headerData);
-    curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 20);
     curl_setopt($ch, CURLOPT_TIMEOUT, 90);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Reverts cosenary/Instagram-PHP-API#100. It's already fixed. Merged commit e2df3f0252e1024fe0f54977125b9ae961b1c617 duplicates [line 556](https://github.com/cosenary/Instagram-PHP-API/blob/master/src/Instagram.php#L556).

```php
curl_setopt($ch, CURLOPT_HEADER, true); // added
curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 20);
curl_setopt($ch, CURLOPT_TIMEOUT, 90);
curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
curl_setopt($ch, CURLOPT_HEADER, true); // already in Instagram.php
```

// cc @vinkla 