### PR TITLE
use access token when it is assigned

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -140,7 +140,12 @@ class Instagram {
    */
   public function getUser($id = 0) {
     $auth = false;
-    if ($id === 0 && isset($this->_accesstoken)) { $id = 'self'; $auth = true; }
+    if (isset($this->_accesstoken)) {
+      $auth = true;
+    }
+    if ($id === 0) {
+      $id = 'self';
+    }
     return $this->_makeCall('users/' . $id, $auth);
   }
 


### PR DESCRIPTION
Previously the access token was not used when accessing the user route for other users. Using it is important for private users.
