### PR TITLE
Save last response http status code

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -86,6 +86,12 @@ class Instagram
      * @var int
      */
     private $_xRateLimitRemaining;
+    
+    /**
+     * Last API Call HTTP Status Code.
+     * @var int
+     */
+    protected $_httpCode;
 
     /**
      * Default constructor.
@@ -635,7 +641,7 @@ class Instagram
         if (!$jsonData) {
             throw new InstagramException('Error: _makeCall() - cURL error: ' . curl_error($ch));
         }
-
+        $this->_httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
         return json_decode($jsonData);
@@ -811,5 +817,14 @@ class Instagram
     public function setSignedHeader($signedHeader)
     {
         $this->_signedheader = $signedHeader;
+    }
+
+    /**
+     * Last API Call HTTP Status Code Getter.
+     * @return int
+     */
+    public function getHttpCode()
+    {
+        return $this->_httpCode;
     }
 }


### PR DESCRIPTION
Hey. I guess it rather handy to have the last api response http status code saved in an object attribute.
How do you think?
