### PR TITLE
When method is DELETE add params to apiCall

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -593,7 +593,7 @@ class Instagram
             $paramString = '&' . http_build_query($params);
         }
 
-        $apiCall = self::API_URL . $function . $authMethod . (('GET' === $method) ? $paramString : null);
+        $apiCall = self::API_URL . $function . $authMethod . (('GET' === $method or 'DELETE' === $method ) ? $paramString : null);
 
         // signed header of POST/DELETE requests
         $headerData = array('Accept: application/json');


### PR DESCRIPTION
DELETE calls to Instagram does not accept parameters in the body of the request.  Therefor parameters need to be added to the query string instead of the body.

