### PR TITLE
Enable pagination for getTagMedia() function

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -375,15 +375,20 @@ class Instagram
      *
      * @param string $name Valid tag name
      * @param int $limit Limit of returned results
+     * @param integer $max_tag_id  Max ID to return (for pagination)
      *
      * @return mixed
      */
-    public function getTagMedia($name, $limit = 0)
+    public function getTagMedia($name, $limit = 0, $max_tag_id = 0)
     {
         $params = array();
 
         if ($limit > 0) {
             $params['count'] = $limit;
+        }
+        
+        if($max_tag_id > 0) {
+            $params['max_tag_id'] = $max_tag_id;
         }
 
         return $this->_makeCall('tags/' . $name . '/media/recent', false, $params);


### PR DESCRIPTION
Add max_tag_id parameter to enable paginating the API resultset beyond the initial limit.