### PR TITLE
Use access token for all requests if available

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -575,7 +575,7 @@ class Instagram
      */
     protected function _makeCall($function, $auth = false, $params = null, $method = 'GET')
     {
-        if (!$auth) {
+        if (!$auth && !isset($this->_accesstoken)) {
             // if the call doesn't requires authentication
             $authMethod = '?client_id=' . $this->getApiKey();
         } else {


### PR DESCRIPTION
Per the recent platform changes (#182), all requests should include an access token. This change uses the token for all API calls if it's been provided, preserving support for apps with legacy client IDs that don't yet require auth for certain methods.
