### PR TITLE
add public_content scope

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -71,7 +71,7 @@ class Instagram
      *
      * @var string[]
      */
-    private $_scopes = array('basic', 'likes', 'comments', 'relationships');
+    private $_scopes = array('basic', 'likes', 'comments', 'relationships', 'public_content' );
 
     /**
      * Available actions.


### PR DESCRIPTION
Instagram's API changes from Dec 2015 require to access the public_content-scope to request e.g. getTagMedia()
