### PR TITLE
require authentication on getTagMedia

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -386,7 +386,7 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('tags/' . $name . '/media/recent', false, $params);
+        return $this->_makeCall('tags/' . $name . '/media/recent', true, $params);
     }
 
     /**


### PR DESCRIPTION
According https://www.instagram.com/developer/endpoints/tags/#get_tags_media_recent the call requires a valid access token. So the parameter auth='false' is the wrong choice in this call.
